### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that powers AI agents with indexed blockchain data from [The Graph](https://thegraph.com/).
 
+<a href="https://glama.ai/mcp/servers/@kukapay/thegraph-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/thegraph-mcp/badge" alt="TheGraph Server MCP server" />
+</a>
+
 ![GitHub License](https://img.shields.io/github/license/kukapay/thegraph-mcp) 
 ![GitHub Last Commit](https://img.shields.io/github/last-commit/kukapay/thegraph-mcp) 
 ![Python Version](https://img.shields.io/badge/python-3.10%2B-blue)


### PR DESCRIPTION
This PR adds a badge for the [TheGraph MCP Server](https://glama.ai/mcp/servers/@kukapay/thegraph-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kukapay/thegraph-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/thegraph-mcp/badge" alt="TheGraph Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.